### PR TITLE
Fixed the route /:path 

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,7 +20,8 @@ def serve(path):
     """Default endpoint, it serves the built static React App
     :return: Served file
     """
-    if path != "" and os.path.exists(app.static_folder + path):
+    file_path = os.path.join(app.static_folder, path)
+    if path != "" and os.path.exists(file_path):
         return send_from_directory(app.static_folder, path)
     else:
         return send_from_directory(app.static_folder, 'index.html')


### PR DESCRIPTION
The 
```
os.path.exists(app.static_folder + path)
```
was not working many times so I fixed it by using path module to first Join the path because string concatenation was having error many a times it would serve HTML file instead of js one,
other reasons from StackOverflow answer:-

Portable
Write filepath manipulations once and it works across many different platforms, for free. The delimiting character is abstracted away, making your job easier.

Smart
You no longer need to worry if that directory path had a trailing slash or not. os.path.join will add it if it needs to.

Clear
Using os.path.join makes it obvious to other people reading your code that you are working with filepaths. People can quickly scan through the code and discover it's a filepath intrinsically. If you decide to construct it yourself, you will likely detract the reader from finding actual problems with your code: "Hmm, some string concats, a substitution. Is this a filepath or what? Gah! Why didn't he use os.path.join?" :)
