### PR TITLE
Incomplete setup and installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The Agent uses a Redis local server as a caching layer. That said, it's necessar
 ```
 sudo ./redis_setup.sh # <- Might be necessary to uso sudo
 ```
+### Running hydrus server
+Since this is an API Client, we need an appropriate hydrus server to query to. To setup a localhost follow the instructions at https://github.com/HTTP-APIs/hydrus#demo. 
+
 
 ### Running the GUI
 If you've installed the Requirements and have the proper Redis running you can simply:


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #93 

### Checklist

- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.8 and above.

### Description
Unlike in the hydra-python-agent documentation, the docs for hydra-python-agent-gui has no mention of running a hydrus server before running `python3 app.py`. Hence when the user runs the app without running the server, it leads to errors.

<!-- Describe about what this PR does, previous state and new state of the output -->
This PR adds/links instructions to setup hydrus server in README.md without which the app would fail.

Previous state:
![Screenshot from 2022-02-26 01-14-10](https://user-images.githubusercontent.com/50960175/155841074-31747ee5-9ee7-4f1f-ad0e-b7b251af9b52.png)

Current state:
The hydrus server is up and running on port http://localhost:8080/serverapi/ and our GUI app is up and running on http://localhost:3000/
![Screenshot from 2022-02-26 16-45-21](https://user-images.githubusercontent.com/50960175/155841131-f0e0f577-63f2-4553-b073-a7341a4a4c46.png)

![Screenshot from 2022-02-26 16-49-10](https://user-images.githubusercontent.com/50960175/155841234-6336626e-1c69-4cd3-8105-7e8b8f8db63a.png)





### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->

<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->

<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->

<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
